### PR TITLE
Add CLI for CFTC TFF crowding analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # crowded_cot
+
+Utility for monitoring crowding in US equity index futures using the CFTC
+Traders in Financial Futures (TFF) report.
+
+## Quick start
+
+Fetch data from the CFTC Public Reporting environment:
+
+```bash
+crowded-cot cftc --start-date 2024-01-01 --end-date 2024-06-01 \
+    --output-csv es_nq.csv --output-json es_nq.json
+```
+
+Or load previously downloaded CSV files:
+
+```bash
+crowded-cot csv --path data/*.csv --output-csv es_nq.csv
+```
+
+The command prints a concise summary of the most recent week and writes tidy
+CSV/JSON files for further analysis.

--- a/crowded_cot/__init__.py
+++ b/crowded_cot/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for analyzing CFTC Traders in Financial Futures data."""
+
+__all__ = [
+    "DataSource",
+    "CftcPRELoader",
+    "CsvFolderLoader",
+    "compute_positioning_metrics",
+]
+
+from .data_source import DataSource, CftcPRELoader, CsvFolderLoader
+from .metrics import compute_positioning_metrics

--- a/crowded_cot/cli.py
+++ b/crowded_cot/cli.py
@@ -1,0 +1,98 @@
+"""Command line interface for the crowded COT tool."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from pathlib import Path
+from typing import Iterable
+
+from .data_source import CftcPRELoader, CsvFolderLoader, DataSource
+from .metrics import compute_positioning_metrics
+
+
+def _parse_date(value: str) -> dt.date:
+    return dt.datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _build_loader(args: argparse.Namespace) -> DataSource:
+    if args.source == "cftc":
+        start = _parse_date(args.start_date)
+        end = _parse_date(args.end_date) if args.end_date else None
+        loader = CftcPRELoader(
+            start_date=start,
+            end_date=end,
+            api_token=args.api_token,
+            dataset_id=args.dataset_id,
+        )
+        return loader
+    if args.source == "csv":
+        loader = CsvFolderLoader(path=args.path)
+        return loader
+    raise ValueError(f"Unknown source: {args.source}")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="source", required=True)
+
+    cftc = sub.add_parser("cftc", help="Load data from the CFTC PRE API")
+    cftc.add_argument("--start-date", required=True, help="YYYY-MM-DD")
+    cftc.add_argument("--end-date", help="YYYY-MM-DD")
+    cftc.add_argument("--api-token", help="Socrata API token")
+    cftc.add_argument(
+        "--dataset-id",
+        default="TFF_COMBINED",
+        help="Key in DATASET_IDS or explicit dataset id",
+    )
+
+    csv = sub.add_parser("csv", help="Load data from local CSV files")
+    csv.add_argument("--path", nargs="+", required=True, help="File paths or globs")
+
+    parser.add_argument("--output-csv", help="Write tidy CSV to this path")
+    parser.add_argument("--output-json", help="Write tidy JSON to this path")
+    parser.add_argument(
+        "--extreme-threshold",
+        type=float,
+        default=2.0,
+        help="Z-score threshold for extreme crowding",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    loader = _build_loader(args)
+    df = loader.load()
+    metrics = compute_positioning_metrics(df, threshold=args.extreme_threshold)
+
+    if args.output_csv:
+        Path(args.output_csv).parent.mkdir(parents=True, exist_ok=True)
+        metrics.to_csv(args.output_csv, index=False)
+    if args.output_json:
+        Path(args.output_json).parent.mkdir(parents=True, exist_ok=True)
+        metrics.to_json(args.output_json, orient="records", date_format="iso")
+
+    if metrics.empty:
+        print("No data returned.")
+        return 0
+
+    latest_date = metrics["report_date"].max()
+    latest = metrics[metrics["report_date"] == latest_date]
+    print(f"Latest report date: {latest_date}")
+    for contract, group in latest.groupby("contract"):
+        row = group.iloc[0]
+        summary = (
+            f"{contract}: asset_mgr_z={row['asset_mgr_z']:.2f}, "
+            f"lev_fund_z={row['lev_fund_z']:.2f}"
+        )
+        if row["extreme_crowding"]:
+            summary += " **EXTREME**"
+        print(summary)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/crowded_cot/data_source.py
+++ b/crowded_cot/data_source.py
@@ -1,0 +1,168 @@
+"""Data loading interfaces for CFTC TFF data."""
+
+from __future__ import annotations
+
+import abc
+import datetime as dt
+import glob
+import json
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Optional
+
+import pandas as pd
+import requests
+
+
+class DataSource(abc.ABC):
+    """Abstract base class for data loaders."""
+
+    @abc.abstractmethod
+    def load(self) -> pd.DataFrame:
+        """Return a dataframe with weekly observations."""
+
+
+# Mapping of logical dataset names to Socrata identifiers.  Users can modify
+# this dictionary to point at alternative datasets if desired.
+DATASET_IDS: Mapping[str, str] = {
+    "TFF_COMBINED": "6p9r-dwsc",  # default Futures + Options Combined dataset
+}
+
+# Market name filters for contracts.  CFTC market names are inconsistent, so we
+# match against any of the provided aliases.
+MARKET_ALIASES: Mapping[str, List[str]] = {
+    "ES": ["E-mini S&P 500", "S&P 500 E-mini"],
+    "NQ": ["E-mini NASDAQ-100", "NASDAQ-100 E-mini"],
+}
+
+# Columns fetched from the CFTC dataset.  Keys are the column names expected in
+# the returned dataframe, values are the column names in the Socrata dataset.
+CFTC_COLUMN_MAP: Mapping[str, str] = {
+    "report_date": "as_of_date_in_form_yyyymmdd",
+    "market_name": "market_and_exchange_names",
+    "open_interest": "open_interest_all",
+    "asset_mgr_long": "asset_mgr_long_all",
+    "asset_mgr_short": "asset_mgr_short_all",
+    "lev_fund_long": "lev_fund_long_all",
+    "lev_fund_short": "lev_fund_short_all",
+}
+
+
+@dataclass
+class CftcPRELoader(DataSource):
+    """Load data from the CFTC Public Reporting environment via Socrata."""
+
+    start_date: dt.date
+    end_date: Optional[dt.date] = None
+    api_token: Optional[str] = None
+    dataset_id: str = "TFF_COMBINED"
+
+    def _resolve_dataset(self) -> str:
+        dataset = DATASET_IDS.get(self.dataset_id, self.dataset_id)
+        return dataset
+
+    def load(self) -> pd.DataFrame:
+        dataset = self._resolve_dataset()
+        select_clause = ",".join(CFTC_COLUMN_MAP.values())
+
+        base_url = f"https://publicreporting.cftc.gov/resource/{dataset}.json"
+
+        where_clauses = [
+            f"{CFTC_COLUMN_MAP['report_date']} >= '{self.start_date.isoformat()}'",
+        ]
+        if self.end_date:
+            where_clauses.append(
+                f"{CFTC_COLUMN_MAP['report_date']} <= '{self.end_date.isoformat()}'"
+            )
+
+        # Market name filters
+        market_filters: List[str] = []
+        for aliases in MARKET_ALIASES.values():
+            joined = ",".join(f"'{a}'" for a in aliases)
+            market_filters.append(
+                f"upper({CFTC_COLUMN_MAP['market_name']}) in (" +
+                ",".join(f"'{a.upper()}'" for a in aliases) + ")"
+            )
+        where_clauses.append("(" + " OR ".join(market_filters) + ")")
+
+        params = {
+            "$select": select_clause,
+            "$where": " AND ".join(where_clauses),
+            "$order": CFTC_COLUMN_MAP['report_date'],
+            "$limit": 50000,
+        }
+
+        headers = {"Accept": "application/json"}
+        if self.api_token:
+            headers["X-App-Token"] = self.api_token
+
+        response = requests.get(base_url, params=params, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = json.loads(response.text)
+        df = pd.DataFrame(data)
+        if df.empty:
+            return df
+
+        # Rename columns to internal names and parse types
+        df = df.rename(columns={v: k for k, v in CFTC_COLUMN_MAP.items()})
+        df["report_date"] = pd.to_datetime(df["report_date"]).dt.date
+        num_cols = [
+            "open_interest",
+            "asset_mgr_long",
+            "asset_mgr_short",
+            "lev_fund_long",
+            "lev_fund_short",
+        ]
+        for col in num_cols:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        # Map market names to contract codes
+        def _contract(name: str) -> Optional[str]:
+            name_upper = name.upper()
+            for code, aliases in MARKET_ALIASES.items():
+                if any(name_upper == a.upper() for a in aliases):
+                    return code
+            return None
+
+        df["contract"] = df["market_name"].apply(_contract)
+        df = df.dropna(subset=["contract"]).reset_index(drop=True)
+        return df
+
+
+@dataclass
+class CsvFolderLoader(DataSource):
+    """Load TFF data from local CSV files."""
+
+    path: Iterable[str]
+
+    def load(self) -> pd.DataFrame:
+        frames: List[pd.DataFrame] = []
+        patterns = list(self.path)
+        for pattern in patterns:
+            for file in glob.glob(pattern):
+                frame = pd.read_csv(file, parse_dates=["report_date"])
+                if "contract" not in frame.columns and "market_name" in frame.columns:
+                    def _contract(name: str) -> Optional[str]:
+                        name_upper = str(name).upper()
+                        for code, aliases in MARKET_ALIASES.items():
+                            if any(name_upper == a.upper() for a in aliases):
+                                return code
+                        return None
+
+                    frame["contract"] = frame["market_name"].apply(_contract)
+                frames.append(frame)
+        if not frames:
+            return pd.DataFrame(columns=CFTC_COLUMN_MAP.keys())
+        df = pd.concat(frames, ignore_index=True)
+        # Ensure date type
+        df["report_date"] = pd.to_datetime(df["report_date"]).dt.date
+        numeric_cols = [
+            "open_interest",
+            "asset_mgr_long",
+            "asset_mgr_short",
+            "lev_fund_long",
+            "lev_fund_short",
+        ]
+        for col in numeric_cols:
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+        return df

--- a/crowded_cot/metrics.py
+++ b/crowded_cot/metrics.py
@@ -1,0 +1,43 @@
+"""Computation of positioning metrics."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_positioning_metrics(df: pd.DataFrame, threshold: float = 2.0) -> pd.DataFrame:
+    """Compute net positions, z-scores and crowding flags.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by a :class:`DataSource`.
+    threshold:
+        Absolute z-score threshold used to flag extreme crowding.
+    """
+
+    if df.empty:
+        return df.copy()
+
+    result = df.copy()
+    result["asset_mgr_net"] = result["asset_mgr_long"] - result["asset_mgr_short"]
+    result["lev_fund_net"] = result["lev_fund_long"] - result["lev_fund_short"]
+
+    # Z-scores computed per contract over the entire history
+    def _zscore(series: pd.Series) -> pd.Series:
+        return (series - series.mean()) / series.std(ddof=0)
+
+    result["asset_mgr_z"] = result.groupby("contract")["asset_mgr_net"].transform(
+        _zscore
+    )
+    result["lev_fund_z"] = result.groupby("contract")["lev_fund_net"].transform(
+        _zscore
+    )
+
+    result["extreme_crowding"] = (
+        result[["asset_mgr_z", "lev_fund_z"]]
+        .abs()
+        .ge(threshold)
+        .any(axis=1)
+    )
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "crowded-cot"
+version = "0.1.0"
+description = "Crowded positioning analysis for CFTC TFF data"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+dependencies = [
+    "pandas",
+    "requests",
+]
+
+[project.scripts]
+crowded-cot = "crowded_cot.cli:main"


### PR DESCRIPTION
## Summary
- Implement DataSource abstraction with Socrata and CSV loaders
- Compute net positions, normalized z-scores, and extreme crowding flag
- Provide CLI to download data, write tidy CSV/JSON, and print weekly summary

## Testing
- `python -m crowded_cot.cli --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python -m pip install pandas requests` *(fails: Cannot connect to proxy, 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc4f592740832781c4e68f8a97beec